### PR TITLE
Removed redundant &0xFF

### DIFF
--- a/src/shoghicp/FastTransfer/StrangePacket.php
+++ b/src/shoghicp/FastTransfer/StrangePacket.php
@@ -32,7 +32,7 @@ class StrangePacket extends DataPacket{
 		$this->putByte($version);
 		if($version === 4){
 			foreach(explode(".", $addr) as $b){
-				$this->putByte((~((int) $b)) & 0xff);
+				$this->putByte(~((int) $b));
 			}
 			$this->putShort($port);
 		}else{


### PR DESCRIPTION
According to a local test in PHP 5.6.3, chr(256) returns a null byte. This shows that chr() used in DataPacket.php returns the integer representation of the least significant byte only, so `& 0xFF` is not necessary.
